### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,7 +109,7 @@ def pack_repo():
 
         cleanup_files()
     except Exception as e:
-        state.output = f"Error: {str(e)}"
+        state.output = "An internal error has occurred. Please try again later."
         print(f"Exception occurred: {str(e)}", file=sys.stderr)
 
     return jsonify({


### PR DESCRIPTION
Fixes [https://github.com/ziadhorat/Repopack-ui/security/code-scanning/4](https://github.com/ziadhorat/Repopack-ui/security/code-scanning/4)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception details and set a generic error message in the response.

- Modify the exception handling block in the `pack_repo` function to log the detailed exception message and set a generic error message in the `state.output`.
- Ensure that the `print` statements used for logging are sufficient for server-side logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
