### PR TITLE
Fix code scanning alert no. 8: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,4 +177,5 @@ def update_config():
     return jsonify({'message': 'Configuration updated successfully'})
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=32123, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=32123, debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/ziadhorat/Repopack-ui/security/code-scanning/8](https://github.com/ziadhorat/Repopack-ui/security/code-scanning/8)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable to control the debug mode. By default, the application should run with debug mode disabled, and it should only be enabled if explicitly set in the environment.

1. Modify the `app.run` statement to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode.
2. Import the `os` module if it is not already imported.
3. Update the `app.run` statement to use the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
