### PR TITLE
Fix code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,8 +64,9 @@ def pack_repo():
     if state.verbose:
         repopack_cmd.append("--verbose")
 
-    # Print the full command being executed
-    print(f"Executing command: {' '.join(repopack_cmd)}", file=sys.stderr)
+    # Print the sanitized command being executed
+    sanitized_cmd = hide_credentials(' '.join(repopack_cmd))
+    print(f"Executing command: {sanitized_cmd}", file=sys.stderr)
 
     try:
         process = subprocess.Popen(repopack_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)


### PR DESCRIPTION
Fixes [https://github.com/ziadhorat/Repopack-ui/security/code-scanning/9](https://github.com/ziadhorat/Repopack-ui/security/code-scanning/9)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. We can achieve this by sanitizing the command before logging it. Specifically, we can replace the sensitive parts of the command with placeholders before logging.

- Modify the `pack_repo` function to sanitize the `repopack_cmd` before logging it.
- Introduce a helper function to sanitize the command by replacing the credentials with placeholders.
- Ensure that the sanitized command is logged instead of the original command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
